### PR TITLE
Typescript support: extend Vue interfaces

### DIFF
--- a/src/types/vue.d.ts
+++ b/src/types/vue.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Extends interfaces in Vue.js
+ */
+
+import Vue from 'vue';
+import VueWait from './index';
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $wait: VueWait;
+  }
+}
+
+declare module 'vue/types/options' {
+  interface ComponentOptions<V extends Vue> {
+    wait?: VueWait;
+  }
+}


### PR DESCRIPTION
Incorporates code from #65 directly into the library so shims are not necessary by consumers of vue-wait. 