### PR TITLE
import vue.d.ts in src/types/index.d.ts

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,5 +1,6 @@
 import Vue, { PluginFunction } from 'vue';
 import { Store } from 'vuex';
+import './vue';
 
 
 type AsyncFunction = ((arg0: any) => Promise<any>) | Promise<any>;


### PR DESCRIPTION
With the following `main.ts` file in a Vue app:
```
import Vue from "vue";
import VueWait from "vue-wait";

import App from "./App.vue";
import "./registerServiceWorker";
import router from "./router";
import store from "./store";

Vue.use(VueWait);

Vue.config.productionTip = false;

new Vue({
  router,
  store,
  render: h => h(App),
  wait: new VueWait({
    useVuex: true,
    vuexModuleName: 'wait',
  }),
}).$mount("#app");
```

I was experiencing this error:
```
31:3 No overload matches this call.
  Overload 1 of 3, '(options?: ThisTypedComponentOptionsWithArrayProps<Vue, object, object, object, never> | undefined): CombinedVueInstance<Vue, object, object, object, Record<...>>', gave the following error.
    Argument of type '{ router: VueRouter; store: Store<unknown>; render: (h: CreateElement) => VNode; wait: VueWait; }' is not assignable to parameter of type 'ThisTypedComponentOptionsWithArrayProps<Vue, object, object, object, never>'.
      Object literal may only specify known properties, and 'wait' does not exist in type 'ThisTypedComponentOptionsWithArrayProps<Vue, object, object, object, never>'.
  Overload 2 of 3, '(options?: ThisTypedComponentOptionsWithRecordProps<Vue, object, object, object, object> | undefined): CombinedVueInstance<Vue, object, object, object, Record<...>>', gave the following error.
    Argument of type '{ router: VueRouter; store: Store<unknown>; render: (h: CreateElement) => VNode; wait: VueWait; }' is not assignable to parameter of type 'ThisTypedComponentOptionsWithRecordProps<Vue, object, object, object, object>'.
      Object literal may only specify known properties, and 'wait' does not exist in type 'ThisTypedComponentOptionsWithRecordProps<Vue, object, object, object, object>'.
  Overload 3 of 3, '(options?: ComponentOptions<Vue, DefaultData<Vue>, DefaultMethods<Vue>, DefaultComputed, PropsDefinition<Record<string, any>>, Record<...>> | undefined): CombinedVueInstance<...>', gave the following error.
    Argument of type '{ router: VueRouter; store: Store<unknown>; render: (h: CreateElement) => VNode; wait: VueWait; }' is not assignable to parameter of type 'ComponentOptions<Vue, DefaultData<Vue>, DefaultMethods<Vue>, DefaultComputed, PropsDefinition<Record<string, any>>, Record<...>>'.
      Object literal may only specify known properties, and 'wait' does not exist in type 'ComponentOptions<Vue, DefaultData<Vue>, DefaultMethods<Vue>, DefaultComputed, PropsDefinition<Record<string, any>>, Record<...>>'.
    29 |   store,
    30 |   render: h => h(App),
  > 31 |   wait: new VueWait({
       |   ^
    32 |     useVuex: true,
    33 |     vuexModuleName: 'wait',
    34 |   }),
Version: typescript 3.9.5
```

My tsconfig.json looks like:
```
{
  "compilerOptions": {
    "target": "esnext",
    "module": "esnext",
    "strict": true,
    "jsx": "preserve",
    "importHelpers": true,
    "moduleResolution": "node",
    "experimentalDecorators": true,
    "esModuleInterop": true,
    "allowSyntheticDefaultImports": true,
    "allowJs": true,
    "resolveJsonModule": true,
    "sourceMap": true,
    "baseUrl": ".",
    "types": [
      "webpack-env",
      "jest"
    ],
    "paths": {
      "@/*": [
        "src/*"
      ]
    },
    "lib": [
      "esnext",
      "dom",
      "dom.iterable",
      "scripthost"
    ]
  },
  "include": [
    "src/**/*.ts",
    "src/**/*.tsx",
    "src/**/*.vue",
    "tests/**/*.ts",
    "tests/**/*.tsx"
  ],
  "exclude": [
    "node_modules"
  ]
}
```

By adding this import the error no longer occurs. I observed this pattern in the vuetify library https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/types/index.d.ts and believe this is the correct fix though I'm not super experienced with Typescript so an update to my tsconfig may be all that's required.