### PR TITLE
Vue 3 support for vue-wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ yarn add vue-wait
 ```
 
 ### 2. Require:
+#### For Vue 2.x
 ```js
 import VueWait from 'vue-wait'
 
@@ -40,6 +41,19 @@ new Vue({
   // your vue config
   wait: new VueWait(),
 })
+```
+
+#### For Vue 3.x
+```js
+import { createApp } from 'vue'
+import { createVueWait } from 'vue-wait'
+import App from './App.vue'
+
+const VueWait = createVueWait()
+
+createApp(App)    // Create app with root component
+  .use(VueWait)   // Register vue-wait
+  .mount('#app')
 ```
 
 ### 3. Use in Your Components

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -117,3 +117,5 @@ export interface VueWaitOptions{
 export function mapWaitingGetters(getters: any): any;
 
 export function mapWaitingActions(vuexModuleName: any, actions?: any): any;
+
+export function createVueWait(options?: VueWaitOptions): Object;


### PR DESCRIPTION
Hi folks!
I present you to Vue 3.x support. With Vue 3 some breaking changes happend. One of these is plugin registration. Plugin registration like below in Vue 2.x:

```js
import VueWait from 'vue-wait'

Vue.use(VueWait)
```

With new version, this implementation changed with that. Let's look at example from Vuex:
```js
import { createApp } from 'vue'
import { createStore } from 'vuex'
import App from './App.vue'

const store = createStore({
  state () {
    return {
      count: 0
    }
  },
  mutations: {
    increment (state) {
      state.count++
    }
  }
})

createApp(App).use(store).mount('#app');
```

According to new implementation, I have been added an install function for Vue 3.x. New registration looks like this:

```js
import { createApp } from 'vue'
import { createVueWait } from 'vue-wait'
import App from './App.vue'

const VueWait = createVueWait({
  useVuex: false,
  registerComponent: true
});

createApp(App).use(VueWait).mount('#app');
```