### PR TITLE
Remove lang="html" in the template.

### DIFF
--- a/src/components/v-wait.vue
+++ b/src/components/v-wait.vue
@@ -1,4 +1,4 @@
-<template lang="html">
+<template>
   <transition
     v-if='transition'
     :name='transition'


### PR DESCRIPTION
After vue-cli 5 upgrade, we are getting an error in jest tests:

```
$ npm run test:unit -- tests/unit/test.spec.ts

Component /.../frontend/node_modules/vue-wait/src/components/v-wait.vue uses lang html for template, however it is not installed.

 FAIL  tests/unit/test.spec.ts
  ● Test suite failed to run

    [vue-jest] Error: Vue template compilation failed
```

Removing lang="html" in the component template fixes the issue.