### PR TITLE
Fix Vue 3 warning when initializing vue-wait.

### DIFF
--- a/src/vue-wait.js
+++ b/src/vue-wait.js
@@ -78,6 +78,9 @@ export default class VueWait {
 
       if (VueWait.getVueVersion(App) > 2) {
         const { createApp } = require('vue');
+        // A template is only needed to avoid Vue 3 warning
+        // [Vue warn]: Component is missing template or render function.
+        config['template'] = '<i></i>';
         this.stateHandler = createApp(config).mount(
           document.createElement('div')
         );
@@ -119,6 +122,9 @@ export default class VueWait {
 
       if (VueWait.getVueVersion(App) > 2) {
         const { createApp } = require('vue');
+        // A template is only needed to avoid Vue 3 warning
+        // [Vue warn]: Component is missing template or render function.
+        config['template'] = '<i></i>';
         this.stateHandler = createApp(config).mount(
           document.createElement('div')
         );


### PR DESCRIPTION
When vue-wait initializes, Vue 3 shows a warning (browser console, console output in tests):

```
[Vue warn]: Component is missing template or render function.
  at <App> ...
```

This PR fixes it by adding a `'<i></i>'` template to the vue-wait's `App` component.